### PR TITLE
fix(preview): preserve scroll position on reload

### DIFF
--- a/src/script.js
+++ b/src/script.js
@@ -239,8 +239,26 @@ function buildwebSrcdoc(withTests=false){
      `;
 }
 
-function runWeb(withTests=false) {
+function runWeb(withTests = false) {
+     let scrollY = 0;
+
+     // Save current scroll position of preview
+     try {
+          scrollY = preview.contentWindow?.scrollY || 0;
+     } catch (e) {
+          scrollY = 0;
+     }
+
+     // Update iframe content
      preview.srcdoc = buildwebSrcdoc(withTests);
+
+     // Restore scroll position after reload
+     preview.onload = () => {
+          try {
+               preview.contentWindow.scrollTo(0, scrollY);
+          } catch (e) {}
+     };
+
      log(withTests ? "Run with Tests" : "Web preview updated.");
 }
 

--- a/src/script.js
+++ b/src/script.js
@@ -249,16 +249,17 @@ function runWeb(withTests = false) {
           scrollY = 0;
      }
 
-     // Update iframe content
-     preview.srcdoc = buildwebSrcdoc(withTests);
-
+     
      // Restore scroll position after reload
-     preview.onload = () => {
+     preview.addEventListener("load", () => {
           try {
                preview.contentWindow.scrollTo(0, scrollY);
           } catch (e) {}
-     };
-
+     }, { once: true });
+     
+     // Update iframe content
+     preview.srcdoc = buildwebSrcdoc(withTests);
+     
      log(withTests ? "Run with Tests" : "Web preview updated.");
 }
 


### PR DESCRIPTION
## Description

This PR fixes the issue where the preview iframe resets its scroll position to the top whenever the preview is reloaded.

### What has changed?

* Saved the current scroll position of the preview iframe before updating `srcdoc`
* Restored the scroll position after the iframe reloads using the `onload` event

### Why is this change needed?

When working with long HTML content, the preview resets to the top on every run or auto-update, making it difficult to test specific sections. This fix preserves the user’s scroll position and improves usability.

---

## Related Issue(s)

Resolves #1 

---

## Type of Change

* [x] Bug fix
* [ ] New feature
* [ ] Refactor (no functional change)
* [ ] Documentation update
* [ ] Chore
* [ ] Hotfix

---

## Checklist

* [x] My code follows the project’s coding standards
* [x] I have performed a self-review
* [ ] I have added/updated tests (if applicable)
* [ ] I have updated documentation (if applicable)
* [x] No breaking changes introduced
* [x] Linked related issue(s)

---

## Testing Details

* [ ] Unit tests
* [x] Manual testing
* [ ] Not applicable

### Testing Steps

1. Open the editor and load a long HTML page
2. Scroll down inside the preview
3. Click "Run" or trigger auto-run by editing code
4. Verify that the scroll position remains unchanged

---

## Screenshots / Recordings (if applicable)

| Before                         | After                                     |
| ------------------------------ | ----------------------------------------- |
| Scroll resets to top on reload | Scroll position is preserved after reload |

---

## Deployment Notes

No special deployment steps required.

---

## Additional Context

This fix improves the usability of the editor when working with long content by preventing disruptive scroll resets.
