### PR TITLE
feat: implement adaptive layout modes for responsive editor UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
      <meta name="author" content="ZAHID SHAIKH">
      <meta name="viewport" content="width=device-width, initial-scale=1.0">
      <title>Code Editor - by Zahid Shaikh</title>
-     <link rel="stylesheet" href="./src/styles.css">
+     <link rel="stylesheet" href="./src/styles.css?v=3">
 </head>
 <body>
      <header>
@@ -16,7 +16,16 @@
                     <div class="title">Code Editor - Live in Browser</div>
                </div>
 
-               <div class="row">
+               <div class="row header-actions">
+
+                    <div class="seg layout-switcher" role="group" aria-label="Layout mode">
+
+                         <button class="seg-btn active" type="button" data-layout="split" title="Editors and preview side by side" aria-pressed="true">Split</button>
+
+                         <button class="seg-btn" type="button" data-layout="stacked" title="Vertical flow" aria-pressed="false">Stack</button>
+
+                         <button class="seg-btn" type="button" data-layout="focus" title="One panel at a time" aria-pressed="false">Focus</button>
+                    </div>
 
                     <button class="btn secondary" id="saveBtn" title="Save work locally"><span>Save</span></button>
 
@@ -25,9 +34,23 @@
                     <input type="file" id="openFile" accept="application/json" hidden>
                </div>
           </div>
+
+          <div class="container row focus-switcher" hidden>
+
+               <div class="seg" role="group" aria-label="Focused panel">
+
+                    <span class="control-label">Focus:</span>
+
+                    <button class="seg-btn active" type="button" data-focus="code" title="Show the code editors" aria-pressed="true">Code</button>
+
+                    <button class="seg-btn" type="button" data-focus="preview" title="Show the preview only" aria-pressed="false">Preview</button>
+
+                    <button class="seg-btn" type="button" data-focus="output" title="Show the output panel" aria-pressed="false">Output</button>
+               </div>
+          </div>
      </header>
 
-     <main>
+     <main data-layout="split" data-focus="code">
           <!-- <aside class="card stack panel">
 
                <h2>Task/Assignment</h2>
@@ -83,32 +106,41 @@
 
                     </div>
 
-                    <div class="tabs" id="webTabs" role="tablist" aria-label="web editors">
+                    <div class="editor-and-preview">
 
-                         <button class="tab active" role="tab" aria-selected="true" tabindex="0" data-pane="html">HTML</button>
+                         <div class="editors-column">
 
-                         <button class="tab" role="tab" aria-selected="false" tabindex="-1" data-pane="css">CSS</button>
+                              <div class="tabs" id="webTabs" role="tablist" aria-label="web editors">
 
-                         <button class="tab" role="tab" aria-selected="false" tabindex="-1" data-pane="js">JavaScript</button>
+                                   <button class="tab active" role="tab" aria-selected="true" tabindex="0" data-pane="html">HTML</button>
 
-                    </div>
+                                   <button class="tab" role="tab" aria-selected="false" tabindex="-1" data-pane="css">CSS</button>
 
-                    <div class="editor-wrap" data-pane="html">
-                         <div id="ed_html" class="editor"></div>
-                    </div>
+                                   <button class="tab" role="tab" aria-selected="false" tabindex="-1" data-pane="js">JavaScript</button>
 
-                    <div class="editor-wrap" data-pane="css" hidden>
-                         <div id="ed_css" class="editor"></div>
-                    </div>
+                              </div>
 
-                    <div class="editor-wrap" data-pane="js" hidden>
-                         <div id="ed_js" class="editor"></div>
-                    </div>
+                              <div class="editor-wrap" data-pane="html">
+                                   <div id="ed_html" class="editor"></div>
+                              </div>
 
-                    <div class="stack">
+                              <div class="editor-wrap" data-pane="css" hidden>
+                                   <div id="ed_css" class="editor"></div>
+                              </div>
 
-                         <h3>Preview</h3>
-                         <iframe id="preview" class="preview" sandbox="allow-scripts allow-same-origin allow-modals"></iframe>
+                              <div class="editor-wrap" data-pane="js" hidden>
+                                   <div id="ed_js" class="editor"></div>
+                              </div>
+                         </div>
+
+                         <div class="preview-column">
+
+                              <div class="stack">
+
+                                   <h3>Preview</h3>
+                                   <iframe id="preview" class="preview" sandbox="allow-scripts allow-same-origin allow-modals"></iframe>
+                              </div>
+                         </div>
                     </div>
                </div>
           </section>
@@ -167,7 +199,7 @@
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.43.2/ext-language_tools.min.js"></script>
 
-     <script src="./src/script.js"></script>
+     <script src="./src/script.js?v=3"></script>
 
 </body>
 </html>

--- a/src/script.js
+++ b/src/script.js
@@ -420,4 +420,81 @@ $("#testArea")?.addEventListener("input", debouncedAutoSave);
 
 initProject();
 log('Ready — Web-only Editor (HTML/CSS/JS) ✨');
+
+
+// ==================== ADAPTIVE LAYOUT MODES =====================
+const mainEl = $("main");
+const LAYOUT_KEY = "editorLayout";
+const FOCUS_KEY = "editorFocus";
+const layoutButtons = $$(".layout-switcher .seg-btn[data-layout]");
+const focusButtons = $$(".focus-switcher .seg-btn[data-focus]");
+const focusSwitcherEl = $(".focus-switcher");
+
+function resizeEditors() {
+     requestAnimationFrame(() => {
+          [ed_html, ed_css, ed_js].forEach((ed) => {
+               if (ed && ed.resize) {
+                    ed.resize(true);
+               }
+          });
+     });
+}
+
+function setFocusPanel(name) {
+     mainEl.dataset.focus = name;
+     focusButtons.forEach((b) => {
+          const on = b.dataset.focus === name;
+          b.classList.toggle("active", on);
+          b.setAttribute("aria-pressed", on);
+     });
+     resizeEditors();
+}
+
+function setLayout(mode, persist = true) {
+     mainEl.dataset.layout = mode;
+     layoutButtons.forEach((b) => {
+          const on = b.dataset.layout === mode;
+          b.classList.toggle("active", on);
+          b.setAttribute("aria-pressed", on);
+     });
+     if (focusSwitcherEl) {
+          focusSwitcherEl.hidden = mode !== "focus";
+     }
+     if (persist) {
+          localStorage.setItem(LAYOUT_KEY, mode);
+     }
+     resizeEditors();
+}
+
+$(".layout-switcher")?.addEventListener("click", (e) => {
+     const b = e.target.closest(".seg-btn");
+     if (!b) {
+          return;
+     }
+     setLayout(b.dataset.layout);
+});
+
+$(".focus-switcher")?.addEventListener("click", (e) => {
+     const b = e.target.closest(".seg-btn");
+     if (!b || !b.dataset.focus) {
+          return;
+     }
+     setFocusPanel(b.dataset.focus);
+     localStorage.setItem(FOCUS_KEY, b.dataset.focus);
+});
+
+const savedLayout = localStorage.getItem(LAYOUT_KEY);
+const savedFocus = localStorage.getItem(FOCUS_KEY) || "code";
+const userPickedLayout = !!savedLayout;
+
+const adaptiveLayout = () => (window.innerWidth < 900 ? "stacked" : "split");
+
+setLayout(savedLayout || adaptiveLayout(), !!savedLayout);
+setFocusPanel(savedFocus);
+
+window.addEventListener("resize", () => {
+     if (!userPickedLayout) {
+          setLayout(adaptiveLayout(), false);
+     }
+});
    

--- a/src/styles.css
+++ b/src/styles.css
@@ -54,7 +54,17 @@ body > header{
      margin-inline: auto;
      padding: 14px;
      justify-content: space-between;
+     gap: 10px;
 
+}
+
+.header-actions{
+     justify-content: flex-end;
+}
+
+.focus-switcher{
+     justify-content: flex-start;
+     padding-top: 0;
 }
 
 .brand{
@@ -81,15 +91,54 @@ main{
      max-width: 1516px;
      margin-inline: auto;
      padding: 18px;
-     display: grid; /*for designing and structuring 2-d Layouts in CSS */
-     grid-template-columns: 1fr 330px;
+     display: grid;
+     grid-template-columns: 1fr;
      gap: var(--gap);
 }
 
-@media (max-width: 1100px){
-     main {
-          grid-template-columns: 1fr;
-     }
+/* Split view: editors + preview side by side, output panel on the right */
+main[data-layout="split"]{
+     grid-template-columns: 1fr 330px;
+}
+
+main[data-layout="split"] .editor-and-preview{
+     grid-template-columns: 1fr 1fr;
+}
+
+/* Stacked / Focus view: single column flow */
+main[data-layout="stacked"] .editor-and-preview,
+main[data-layout="focus"] .editor-and-preview{
+     grid-template-columns: 1fr;
+}
+
+.editor-and-preview{
+     display: grid;
+     grid-template-columns: 1fr;
+     gap: var(--gap);
+     align-items: start;
+}
+
+.editors-column,
+.preview-column{
+     min-width: 0;
+     display: flex;
+     flex-direction: column;
+     gap: var(--gap);
+}
+
+/* Focus mode: show a single panel at a time */
+main[data-layout="focus"][data-focus="code"] .preview-column,
+main[data-layout="focus"][data-focus="code"] aside.panel{
+     display: none;
+}
+
+main[data-layout="focus"][data-focus="preview"] .editors-column,
+main[data-layout="focus"][data-focus="preview"] aside.panel{
+     display: none;
+}
+
+main[data-layout="focus"][data-focus="output"] #web-only{
+     display: none;
 }
 
 .card{
@@ -190,6 +239,46 @@ textarea.text{
 .tab.active{
      background: linear-gradient(180deg, rgba(125, 211, 252, 0.18), rgba(96, 165, 250, 0.18));
      color: #00FF00 !important;
+}
+
+.seg{
+     display: inline-flex;
+     align-items: center;
+     flex-wrap: wrap;
+     gap: 2px;
+     padding: 4px;
+     background: rgba(255,255,255,0.05);
+     border: 1px solid rgba(255,255,255,0.12);
+     border-radius: 12px;
+     width: fit-content;
+     max-width: 100%;
+}
+
+.seg[hidden]{
+     display: none;
+}
+
+.seg-btn{
+     appearance: none;
+     border: none;
+     background: transparent;
+     color: var(--muted);
+     font-weight: 700;
+     font-size: 13px;
+     line-height: 1;
+     padding: 7px 12px;
+     border-radius: 9px;
+     cursor: pointer;
+     transition: background 0.15s ease, color 0.15s ease;
+}
+
+.seg-btn:hover{
+     color: var(--txt);
+}
+
+.seg-btn.active{
+     background: linear-gradient(180deg, rgba(125, 211, 252, 0.22), rgba(96, 165, 250, 0.22));
+     color: var(--brand);
 }
 
 .editor-wrap{

--- a/tests/editor.test.md
+++ b/tests/editor.test.md
@@ -35,6 +35,17 @@
 - [ ] Ctrl / Cmd + Enter runs code
 - [ ] Ctrl / Cmd + S saves project
 
+## Adaptive Layout Modes
+- [ ] Layout switcher (Split / Stack / Focus) is visible in the header
+- [ ] Split view shows editors and preview side by side, output on the right
+- [ ] Stacked view flows vertically: editors, then preview, then output
+- [ ] Focus mode shows a single panel at a time (Code / Preview / Output)
+- [ ] Focus switcher appears only in Focus mode
+- [ ] Ace editors resize correctly during layout transitions
+- [ ] Chosen layout persists after page reload
+- [ ] Focus panel persists after page reload
+- [ ] First visit on a narrow viewport defaults to Stacked mode
+
 ## Cross-Browser
 - [ ] Works in Chrome
 - [ ] Works in Edge


### PR DESCRIPTION
## Description

Implements adaptive layout modes for Issue #9, replacing breakpoint-only responsiveness with explicit user-selectable layouts.

## Changes

- Added Split, Stacked, and Focus layout modes.
- Added a segmented layout mode selector.
- Added Code/Preview/Output switcher for Focus mode.
- Added localStorage persistence for layout preferences.
- Added adaptive Stacked default for narrow first-time visits.
- Added Ace editor resize handling during layout transitions.
- Updated `editor.test.md` with manual test cases.

## Testing

- Verified Split mode.
- Verified Stacked mode.
- Verified Focus mode.
- Verified Code/Preview/Output switching.
- Verified localStorage persistence.
- Verified Ace editor resizing.
- Verified narrow-screen default behavior.
- Ran available tests.
- Ran linting if available.
- Ran build checks if available.

## Screenshots

### Before
<img width="1470" height="799" alt="Screenshot 2026-08-16 at 4 48 30 PM" src="https://github.com/user-attachments/assets/dd0cb4c4-4566-4eb5-b7cb-b4ecd29d9229" />
<img width="607" height="789" alt="Screenshot 2026-08-16 at 4 48 57 PM" src="https://github.com/user-attachments/assets/06b14a8d-8437-4432-a5bf-19e4ee3b9d17" />


### After
<img width="394" height="718" alt="Screenshot 2026-08-16 at 4 36 36 PM" src="https://github.com/user-attachments/assets/4f09dab3-effb-42e5-994c-94b7d988ae24" />
<img width="563" height="758" alt="Screenshot 2026-08-16 at 4 37 15 PM" src="https://github.com/user-attachments/assets/0acbe54b-d2af-4594-9874-34929eea8e59" />
<img width="998" height="689" alt="Screenshot 2026-08-16 at 4 38 05 PM" src="https://github.com/user-attachments/assets/25416408-2075-407f-85de-f5b42af98c17" />


## Related Issue

Closes #9
